### PR TITLE
Feat: Allow closing widget via inventory key

### DIFF
--- a/common/src/main/java/dev/drtheo/spellwheel/client/WheelKeybinds.java
+++ b/common/src/main/java/dev/drtheo/spellwheel/client/WheelKeybinds.java
@@ -8,6 +8,7 @@ import dev.architectury.registry.client.keymappings.KeyMappingRegistry;
 import dev.drtheo.spellwheel.client.ui.WheelScreen;
 import dev.drtheo.spellwheel.client.util.SpellbookUtil;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 
 public class WheelKeybinds {
 
@@ -22,6 +23,10 @@ public class WheelKeybinds {
         // TODO: find a better way to catch hotbar keys
         ClientRawInputEvent.KEY_PRESSED.register((client, keyCode, scanCode, action, modifiers) -> {
             if (!(client.screen instanceof WheelScreen wheelScreen) || action != 1) return EventResult.pass();
+            if (Minecraft.getInstance().options.keyInventory.matches(keyCode, scanCode)) {
+                wheelScreen.onClose();
+                return EventResult.interruptDefault();
+            }
             if (keyCode < InputConstants.KEY_1 || keyCode > InputConstants.KEY_9) return EventResult.pass();
 
             wheelScreen.simulateClick(keyCode - InputConstants.KEY_1);


### PR DESCRIPTION
Allows closing the widget via the inventory key.

QoL so you don't have to move your hand to the ESC key if you want to cancel, similar to how e.g. the Anvil or other GUIs work.